### PR TITLE
fsize change

### DIFF
--- a/fsize.effekt
+++ b/fsize.effekt
@@ -9,10 +9,9 @@ def tree_filter_iterate[A] (tr: Tree[A]) { f: A => Boolean / {} } : Unit / Yield
     tr match {
         case Nil() => ()
         case Node(l, r, v) =>
-            if (if (f(v)) { do Yield(v) } else { true }) {
-                tree_filter_iterate(l){f};
-                tree_filter_iterate(r){f}
-            } else { () }
+            tree_filter_iterate(l){f};
+            tree_filter_iterate(r){f}
+            if (f(v)) { do Yield(v) }
     }
 }
 

--- a/fsize.effekt
+++ b/fsize.effekt
@@ -1,4 +1,4 @@
-effect Yield[A](elem: A): Boolean
+effect Yield[A](elem: A): Unit
 
 type Tree[A] {
     Nil()
@@ -29,7 +29,7 @@ def tree_filter_size_direct[A] (tr: Tree[A]) { f: A => Boolean / {} }: Int / {} 
 def tree_filter_size_indirect[A] (tr: Tree[A]) { f: A => Boolean / {} }: Int / {} = {
     var num = 0;
     try { tree_filter_iterate(tr){f}; num }
-    with Yield[A] { _ => num = num + 1; resume(true) }
+    with Yield[A] { _ => num = num + 1; resume() }
 }
 
 def generate_tree(d: Int, n: Int) : Tree[Int] = {
@@ -46,10 +46,10 @@ def main() = {
     val tree = generate_tree(10, 3);
     val n1 = try {
                  tree_filter_size_direct(tree) { n => do Yield(n); n > 0 }
-             } with Yield[Int] { _ => resume(true) };
+             } with Yield[Int] { _ => resume() };
     val n2 = try {
                  tree_filter_size_indirect(tree) { n => do Yield(n); n > 0 }
-             } with Yield[Int] { _ => resume(true) };
+             } with Yield[Int] { _ => resume() };
     println(n1);
     println(n2);
 }

--- a/fsize.kk
+++ b/fsize.kk
@@ -1,4 +1,4 @@
-effect ctl yield(elem: a): bool
+effect ctl yield(elem: a): unit
 
 type tree<a>
   Empty
@@ -25,7 +25,7 @@ fun tree_filter_size_indirect(tr: tree<a>, f: a -> bool): int
   var num := 0
   with ctl yield(_)
     num := num + 1
-    resume(True)
+    resume()
   tree_filter_iterate(tr, f)
   num
 
@@ -41,7 +41,7 @@ fun main()
   val tree = generate_tree(10, 3)
   val n1 =
     with ctl yield(_)
-      resume(True)
+      resume()
     tree_filter_size_direct(tree,
       fn (n) {
         yield(n)
@@ -49,7 +49,7 @@ fun main()
       })
   val n2 =
     with ctl yield(_)
-      resume(True)
+      resume()
     tree_filter_size_indirect(tree,
       fn (n) {
         yield(n)

--- a/fsize.kk
+++ b/fsize.kk
@@ -52,7 +52,7 @@ fun main()
       resume(True)
     tree_filter_size_indirect(tree,
       fn (n) {
-        /* yield(n) */
+        yield(n)
         n > 0
       })
   n1.println

--- a/fsize.kk
+++ b/fsize.kk
@@ -8,10 +8,9 @@ fun tree_filter_iterate(tr: tree<a>, f: a -> bool): yield ()
   match tr
     Empty -> ()
     Node(l, r, v) ->
-      val cont = if f(v) then yield(v) else True
-      if cont then
-        tree_filter_iterate(l, f)
-        tree_filter_iterate(r, f)
+      tree_filter_iterate(l, f)
+      tree_filter_iterate(r, f)
+      if f(v) then yield(v)
 
 fun tree_filter_size_direct(tr: tree<a>, f: a -> e bool): e int
   match tr


### PR DESCRIPTION
`tree_filter_iterate` should iterate over all elements in the tree. On each element, do yield depending on f(v). The current implementation doesn't conform with that.

Here's the fliterate from the paper.

![image](https://user-images.githubusercontent.com/8647872/200138379-b67eb8d2-a5dd-4353-ad63-aecae5f2cda7.png)
